### PR TITLE
feat: Use ceph release name instead of version

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -27,15 +27,14 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 16.2.9
-          - 17.2.6
+          - pacific
+          - quincy
         scenario:
           - aio
           - ha
         distro:
           - ubuntu2004
-          # NOTE(mnaser): There are no Jammy packages for Ceph yet.
-          # - ubuntu2204
+          - ubuntu2204
     steps:
       - name: Checkout project
         uses: actions/checkout@v3

--- a/molecule/aio/molecule.yml
+++ b/molecule/aio/molecule.yml
@@ -44,7 +44,7 @@ provisioner:
     group_vars:
       all:
         ceph_fsid: ${MOLECULE_CEPH_FSID:-"1dff0e0f-3c44-48da-81cd-4f3c6e8722b2"}
-        ceph_version: ${MOLECULE_CEPH_VERSION:-"16.2.9"}
+        ceph_release_name: ${MOLECULE_CEPH_VERSION:-"pacific"}
         ceph_conf_overrides:
           - section: global
             option: osd crush chooseleaf type

--- a/molecule/ha/molecule.yml
+++ b/molecule/ha/molecule.yml
@@ -60,7 +60,7 @@ provisioner:
     group_vars:
       all:
         ceph_fsid: ${MOLECULE_CEPH_FSID:-"1dff0e0f-3c44-48da-81cd-4f3c6e8722b2"}
-        ceph_version: ${MOLECULE_CEPH_VERSION:-"16.2.9"}
+        ceph_release_name: ${MOLECULE_CEPH_VERSION:-"pacific"}
         ceph_conf_overrides:
           - section: mon
             option: auth allow insecure global id reclaim

--- a/roles/osd/tasks/main.yml
+++ b/roles/osd/tasks/main.yml
@@ -21,7 +21,7 @@
   ansible.builtin.apt:
     name: ["ceph-volume"]
     install_recommends: false
-  when: ceph_repository_version is ansible.builtin.version("17.2", '>=')
+  when: ceph_release_name in ["quincy"]
 
 - name: Collect "ceph mon dump" output from a monitor
   delegate_to: "{{ groups[ceph_osd_mons_group][0] }}"

--- a/roles/repository/defaults/main.yml
+++ b/roles/repository/defaults/main.yml
@@ -12,8 +12,8 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-# Ceph version to pin package manager to
-ceph_repository_version: "{{ ceph_version | default('16.2.9') }}"
+# Ceph release name to pin package manager to. Pacific and Quincy are supported.
+ceph_release_name: "pacific"
 
 # Ceph APT repository URL
-ceph_repository_url: https://download.ceph.com/debian-{{ ceph_repository_version }}/
+ceph_repository_url: https://download.ceph.com/debian-{{ ceph_release_name }}/

--- a/roles/repository/tasks/main.yml
+++ b/roles/repository/tasks/main.yml
@@ -12,10 +12,10 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-- name: Check if ceph_repository_version minimal 16.2
+- name: Check if ceph_release_name is in the support list 
   ansible.builtin.fail:
-    msg: ceph_repository_version older then 16.2 or has the incorrect format.
-  when: ceph_repository_version is not ansible.builtin.version("16.2", '>=')
+    msg: ceph_release_name should be pacific or quincy.
+  when: ceph_release_name not in ["pacific", "quincy"]
 
 - name: Install packages
   ansible.builtin.apt:


### PR DESCRIPTION
drive-by: Add jammy test in the CI