### PR TITLE
fix(osd): Run ceph-volume lvm list on all nodes independently

### DIFF
--- a/roles/osd/tasks/main.yml
+++ b/roles/osd/tasks/main.yml
@@ -81,7 +81,6 @@
     osd_query: "[?starts_with(name, 'osd.')]"
 
 - name: Get `ceph-volume lvm list` status
-  run_once: true
   ansible.builtin.command: cephadm shell -- ceph-volume lvm list --format json
   register: ceph_lvm_stat
   changed_when: false


### PR DESCRIPTION
Avoids working with mismatched lvm data on new nodes (and skipping adding OSDs by consequence).

Fixes #35