### PR TITLE
Enable CEPH mgr prometheus module

### DIFF
--- a/roles/mgr/tasks/main.yml
+++ b/roles/mgr/tasks/main.yml
@@ -49,5 +49,4 @@
       --fsid "{{ ceph_mgr_fsid }}"
       --config "/var/lib/ceph/{{ ceph_mgr_fsid }}/mon.{{ inventory_hostname_short }}/config"
       -- ceph mgr module enable prometheus
-  register: result
-  changed_when: result.rc == 0
+  changed_when: false

--- a/roles/mgr/tasks/main.yml
+++ b/roles/mgr/tasks/main.yml
@@ -49,3 +49,5 @@
       --fsid "{{ ceph_mgr_fsid }}"
       --config "/var/lib/ceph/{{ ceph_mgr_fsid }}/mon.{{ inventory_hostname_short }}/config"
       -- ceph mgr module enable prometheus
+  register: result
+  changed_when: result.rc == 0

--- a/roles/mgr/tasks/main.yml
+++ b/roles/mgr/tasks/main.yml
@@ -42,3 +42,10 @@
   retries: "{{ ceph_mon_check_retry | default(120) }}"
   delay: 3
   changed_when: false
+
+- name: Enable the Ceph Manager prometheus module
+  ansible.builtin.command: |
+    cephadm shell
+      --fsid "{{ ceph_mgr_fsid }}"
+      --config "/var/lib/ceph/{{ ceph_mgr_fsid }}/mon.{{ inventory_hostname_short }}/config"
+      -- ceph mgr module enable prometheus


### PR DESCRIPTION
Fixes #38
It is essential to enable ceph mgr prometheus module, so that ceph cluster metrics can be collected and alert rules can take effect. 