### PR TITLE
feat(playbooks): add ceph_skip_loopback_check variable

### DIFF
--- a/extensions/molecule/default/prepare.yml
+++ b/extensions/molecule/default/prepare.yml
@@ -27,6 +27,6 @@
   ansible.builtin.import_playbook: vexxhost.ceph.create_fake_devices
 
 - name: Re-run fake devices with loopback precheck disabled
-  import_playbook: vexxhost.ceph.create_fake_devices
+  ansible.builtin.import_playbook: vexxhost.ceph.create_fake_devices
   vars:
     ceph_skip_loopback_check: true

--- a/extensions/molecule/default/prepare.yml
+++ b/extensions/molecule/default/prepare.yml
@@ -27,6 +27,6 @@
   ansible.builtin.import_playbook: vexxhost.ceph.create_fake_devices
 
 - name: Re-run fake devices with loopback precheck disabled
-  ansible.builtin.import_playbook: vexxhost.ceph.create_fake_devices
+  import_playbook: vexxhost.ceph.create_fake_devices
   vars:
     ceph_skip_loopback_check: true

--- a/extensions/molecule/default/prepare.yml
+++ b/extensions/molecule/default/prepare.yml
@@ -26,7 +26,13 @@
 - name: Create fake devices
   ansible.builtin.import_playbook: vexxhost.ceph.create_fake_devices
 
+- name: Enable loopback precheck skip for coverage
+  hosts: cephs
+  gather_facts: false
+  tasks:
+    - name: Set loopback precheck skip variable
+      ansible.builtin.set_fact:
+        ceph_skip_loopback_check: true
+
 - name: Re-run fake devices with loopback precheck disabled
   ansible.builtin.import_playbook: vexxhost.ceph.create_fake_devices
-  vars:
-    ceph_skip_loopback_check: true

--- a/extensions/molecule/default/prepare.yml
+++ b/extensions/molecule/default/prepare.yml
@@ -25,3 +25,8 @@
 
 - name: Create fake devices
   ansible.builtin.import_playbook: vexxhost.ceph.create_fake_devices
+
+- name: Re-run fake devices with loopback precheck disabled
+  ansible.builtin.import_playbook: vexxhost.ceph.create_fake_devices
+  vars:
+    ceph_skip_loopback_check: true

--- a/extensions/molecule/default/prepare.yml
+++ b/extensions/molecule/default/prepare.yml
@@ -25,14 +25,3 @@
 
 - name: Create fake devices
   ansible.builtin.import_playbook: vexxhost.ceph.create_fake_devices
-
-- name: Enable loopback precheck skip for coverage
-  hosts: cephs
-  gather_facts: false
-  tasks:
-    - name: Set loopback precheck skip variable
-      ansible.builtin.set_fact:
-        ceph_skip_loopback_check: true
-
-- name: Re-run fake devices with loopback precheck disabled
-  ansible.builtin.import_playbook: vexxhost.ceph.create_fake_devices

--- a/playbooks/create_fake_devices.yml
+++ b/playbooks/create_fake_devices.yml
@@ -59,11 +59,14 @@
       ansible.builtin.command: losetup -a
       changed_when: false
       register: _loopback_devices
+      when: not (ceph_skip_loopback_check | default(false) | bool)
 
     - name: Fail if there is any existing loopback devices
       ansible.builtin.fail:
         msg: There are existing loopback devices, please ensure they are removed
-      when: _loopback_devices.stdout != ""
+      when:
+        - not (ceph_skip_loopback_check | default(false) | bool)
+        - _loopback_devices.stdout | default("") != ""
 
     - name: Create devices for Ceph
       ansible.builtin.command: truncate -s 1024G /opt/{{ inventory_hostname_short }}-{{ item }}.img


### PR DESCRIPTION
## Summary
Add a `ceph_skip_loopback_check` variable to `playbooks/create_fake_devices.yml` to optionally skip the precondition tasks that list loopback devices and fail if any exist.

## Motivation
When reusing test hosts that already have unrelated loopback devices configured, the playbook unconditionally fails. This adds an opt-in escape hatch.

## Usage
```yaml
ansible-playbook playbooks/create_fake_devices.yml -e ceph_skip_loopback_check=true
```

Default behavior is unchanged (`false`).