### PR TITLE
fix(key): restore info state compatibility

### DIFF
--- a/extensions/molecule/default/verify.yml
+++ b/extensions/molecule/default/verify.yml
@@ -50,6 +50,21 @@
           - (_key_info.stdout | from_json)[0].key is defined
           - (_key_info.stdout | from_json)[0].caps.mon == 'allow r'
           - (_key_info.stdout | from_json)[0].caps.osd == 'allow rwx pool=test-pool'
+
+    - name: Retrieve info for the test Ceph key using the legacy key module
+      vexxhost.ceph.key:
+        name: client.test
+        state: info
+      register: _legacy_key_info
+
+    - name: Assert that the legacy key module info state returns the correct key
+      ansible.builtin.assert:
+        that:
+          - _legacy_key_info.rc == 0
+          - (_legacy_key_info.stdout | from_json)[0].entity == 'client.test'
+          - (_legacy_key_info.stdout | from_json)[0].key is defined
+          - (_legacy_key_info.stdout | from_json)[0].caps.mon == 'allow r'
+          - (_legacy_key_info.stdout | from_json)[0].caps.osd == 'allow rwx pool=test-pool'
   environment:
     CEPHADM_IMAGE: "quay.io/ceph/ceph:v{{ ceph_version }}"
     CEPH_CONTAINER_IMAGE: "quay.io/ceph/ceph:v{{ ceph_version }}"

--- a/plugins/modules/key.py
+++ b/plugins/modules/key.py
@@ -80,11 +80,12 @@ options:
             the keyring if the secret changes, the same goes for
             the capabilities.
             If 'absent' is used, the module will simply delete the keyring.
+            If 'info' is used, the module will return in a json format the
+            description of a given keyring.
             If 'list' is used, the module will list all the keys and will
             return a json output.
             If 'generate_secret' is used, the module will simply output a cephx keyring.
         required: false
-        choices: ['present', 'update', 'absent', 'fetch_initial_keys', 'generate_secret']
         default: present
     caps:
         description:
@@ -180,6 +181,11 @@ caps:
 - name: fetch cephx keys
   ceph_key:
     state: fetch_initial_keys
+
+- name: info cephx key
+  ceph_key:
+    name: client.admin
+    state: info
 '''
 
 RETURN = '''#  '''
@@ -187,6 +193,8 @@ RETURN = '''#  '''
 
 CEPH_INITIAL_KEYS = ['client.admin', 'client.bootstrap-mds', 'client.bootstrap-mgr',  # noqa: E501
                      'client.bootstrap-osd', 'client.bootstrap-rbd', 'client.bootstrap-rbd-mirror', 'client.bootstrap-rgw']  # noqa: E501
+STATE_CHOICES = ['present', 'update', 'absent', 'info', 'list',
+                 'fetch_initial_keys', 'generate_secret']
 
 
 def str_to_bool(val):
@@ -465,8 +473,7 @@ def run_module():
     module_args = dict(
         cluster=dict(type='str', required=False, default='ceph'),
         name=dict(type='str', required=False),
-        state=dict(type='str', required=False, default='present', choices=['present', 'update', 'absent',  # noqa: E501
-                                                                           'fetch_initial_keys', 'generate_secret']),  # noqa: E501
+        state=dict(type='str', required=False, default='present'),
         caps=dict(type='dict', required=False, default=None),
         secret=dict(type='str', required=False, default=None, no_log=True),
         import_key=dict(type='bool', required=False, default=True),
@@ -496,8 +503,12 @@ def run_module():
     user_key = module.params.get('user_key')
     output_format = module.params.get('output_format')
 
+    if state not in STATE_CHOICES:
+        fatal("value of state must be one of: {}, got: {}".format(
+            ', '.join(STATE_CHOICES), state), module)
+
     # Can't use required_if with 'name' for some reason...
-    if state in ['present', 'absent', 'update'] and not name:
+    if state in ['present', 'absent', 'update', 'info'] and not name:
         fatal(f'"state" is "{state}" but "name" is not defined.', module)
 
     changed = False
@@ -534,7 +545,15 @@ def run_module():
     else:
         user_key_path = user_key
 
-    if (state in ["present", "update"]):
+    if state == "info":
+        rc, cmd, out, err = exec_commands(
+            module, info_key(cluster, name, user, user_key_path, output_format, container_image))  # noqa: E501
+
+    elif state == "list":
+        rc, cmd, out, err = exec_commands(
+            module, list_keys(cluster, user, user_key_path, container_image))
+
+    elif (state in ["present", "update"]):
         # if dest is not a directory, the user wants to change the file's name
         # (e,g: /etc/ceph/ceph.mgr.ceph-mon2.keyring)
         if not os.path.isdir(dest):


### PR DESCRIPTION
## Summary

- restore `vexxhost.ceph.key` support for legacy `state: info` and `state: list` callers
- keep the newer `vexxhost.ceph.key_info` module in place
- add molecule coverage for the legacy `key` module `state: info` path

## Validation

- `nix-shell -p python3 --run 'python -m py_compile plugins/modules/key.py plugins/modules/key_info.py'`
- `nix-shell -p ansible-lint --run 'ansible-lint extensions/molecule/default/verify.yml'`
- `nix-shell -p ansible --run 'ANSIBLE_COLLECTIONS_PATH=/tmp/acceph-test ansible localhost -c local -m vexxhost.ceph.key -a "name=client.test state=info" --check'`

`ansible-test sanity --local --test validate-modules plugins/modules/key.py` still reports the pre-existing module documentation/license issues for `key.py`, but the new invalid `state` choices were avoided by moving compatibility validation into module code.