### PR TITLE
feat: use Ceph 20.2.3 and support Ubuntu Noble

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -60,7 +60,6 @@
     abstract: true
     vars:
       ceph_fsid: 1dff0e0f-3c44-48da-81cd-4f3c6e8722b2
-      ceph_version: 18.2.8
       ceph_osd_devices:
         - /dev/ceph-{{ inventory_hostname_short }}-osd0/data
         - /dev/ceph-{{ inventory_hostname_short }}-osd1/data

--- a/extensions/molecule/default/verify.yml
+++ b/extensions/molecule/default/verify.yml
@@ -5,67 +5,93 @@
   hosts: controllers
   become: true
   tasks:
-    - name: Get cluster health status
-      ansible.builtin.command: cephadm shell -- ceph health
-      register: _ceph_health
+    - name: List locally deployed Ceph daemons
+      ansible.builtin.command: cephadm ls
+      register: _cephadm_daemons
       changed_when: false
 
-    - name: Print cluster health status
-      ansible.builtin.debug:
-        var: _ceph_health
+    - name: Collect deployed Ceph container images
+      ansible.builtin.set_fact:
+        _ceph_container_images: >-
+          {{
+            _cephadm_daemons.stdout
+            | from_json
+            | selectattr('name', 'match', '^mon[.]')
+            | selectattr('container_image_name', 'defined')
+            | map(attribute='container_image_name')
+            | unique
+            | list
+          }}
 
-    - name: Assert that the cluster status is healthy
+    - name: Assert that a deployed Ceph container image was found
       ansible.builtin.assert:
         that:
-          - _ceph_health.stdout == 'HEALTH_OK'
+          - _ceph_container_images | length > 0
+        fail_msg: No deployed monitor container image was found in cephadm metadata
 
-    - name: Create a test Ceph pool
-      vexxhost.ceph.pool:
-        name: test-pool
-        state: present
-        size: "1"
-        min_size: "1"
-        application: rbd
-        pg_autoscale_mode: "on"
+    - name: Verify using the deployed Ceph container image
+      environment:
+        CEPHADM_IMAGE: "{{ _ceph_container_images | first }}"
+        CEPH_CONTAINER_IMAGE: "{{ _ceph_container_images | first }}"
+        CEPH_CONTAINER_BINARY: docker
+      block:
+        - name: Get cluster health status
+          ansible.builtin.command: cephadm shell -- ceph health
+          register: _ceph_health
+          changed_when: false
 
-    - name: Create a test Ceph key
-      vexxhost.ceph.key:
-        name: client.test
-        state: present
-        caps:
-          mon: "allow r"
-          osd: "allow rwx pool=test-pool"
+        - name: Print cluster health status
+          ansible.builtin.debug:
+            var: _ceph_health
 
-    - name: Retrieve info for the test Ceph key
-      vexxhost.ceph.key_info:
-        name: client.test
-        state: info
-      register: _key_info
+        - name: Assert that the cluster status is healthy
+          ansible.builtin.assert:
+            that:
+              - _ceph_health.stdout == 'HEALTH_OK'
 
-    - name: Assert that key_info returns the correct key
-      ansible.builtin.assert:
-        that:
-          - _key_info.rc == 0
-          - (_key_info.stdout | from_json)[0].entity == 'client.test'
-          - (_key_info.stdout | from_json)[0].key is defined
-          - (_key_info.stdout | from_json)[0].caps.mon == 'allow r'
-          - (_key_info.stdout | from_json)[0].caps.osd == 'allow rwx pool=test-pool'
+        - name: Create a test Ceph pool
+          vexxhost.ceph.pool:
+            name: test-pool
+            state: present
+            size: "1"
+            min_size: "1"
+            application: rbd
+            pg_autoscale_mode: "on"
 
-    - name: Retrieve info for the test Ceph key using the legacy key module
-      vexxhost.ceph.key:
-        name: client.test
-        state: info
-      register: _legacy_key_info
+        - name: Create a test Ceph key
+          vexxhost.ceph.key:
+            name: client.test
+            state: present
+            caps:
+              mon: "allow r"
+              osd: "allow rwx pool=test-pool"
 
-    - name: Assert that the legacy key module info state returns the correct key
-      ansible.builtin.assert:
-        that:
-          - _legacy_key_info.rc == 0
-          - (_legacy_key_info.stdout | from_json)[0].entity == 'client.test'
-          - (_legacy_key_info.stdout | from_json)[0].key is defined
-          - (_legacy_key_info.stdout | from_json)[0].caps.mon == 'allow r'
-          - (_legacy_key_info.stdout | from_json)[0].caps.osd == 'allow rwx pool=test-pool'
-  environment:
-    CEPHADM_IMAGE: "quay.io/ceph/ceph:v{{ ceph_version }}"
-    CEPH_CONTAINER_IMAGE: "quay.io/ceph/ceph:v{{ ceph_version }}"
-    CEPH_CONTAINER_BINARY: docker
+        - name: Retrieve info for the test Ceph key
+          vexxhost.ceph.key_info:
+            name: client.test
+            state: info
+          register: _key_info
+
+        - name: Assert that key_info returns the correct key
+          ansible.builtin.assert:
+            that:
+              - _key_info.rc == 0
+              - (_key_info.stdout | from_json)[0].entity == 'client.test'
+              - (_key_info.stdout | from_json)[0].key is defined
+              - (_key_info.stdout | from_json)[0].caps.mon == 'allow r'
+              - (_key_info.stdout | from_json)[0].caps.osd == 'allow rwx pool=test-pool'
+
+        - name: Retrieve info for the test Ceph key using the legacy key module
+          vexxhost.ceph.key:
+            name: client.test
+            state: info
+          register: _legacy_key_info
+
+        - name: Assert that the legacy key module info state returns the correct key
+          ansible.builtin.assert:
+            that:
+              - _legacy_key_info.rc == 0
+              - (_legacy_key_info.stdout | from_json)[0].entity == 'client.test'
+              - (_legacy_key_info.stdout | from_json)[0].key is defined
+              - (_legacy_key_info.stdout | from_json)[0].caps.mon == 'allow r'
+              - (_legacy_key_info.stdout | from_json)[0].caps.osd == 'allow rwx pool=test-pool'

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -23,7 +23,7 @@
       tags:
         - ceph-mgr
   environment:
-    CEPH_CONTAINER_IMAGE: "{{ cephadm_image | default('quay.io/ceph/ceph:v' + (ceph_version | default('18.2.1'))) }}"
+    CEPH_CONTAINER_IMAGE: "{{ cephadm_image | default('quay.io/ceph/ceph:v' + (ceph_version | default('20.2.3'))) }}"
     CEPH_CONTAINER_BINARY: docker
 
 - name: Deploy Ceph OSDs
@@ -34,7 +34,7 @@
       tags:
         - ceph-osd
   environment:
-    CEPH_CONTAINER_IMAGE: "{{ cephadm_image | default('quay.io/ceph/ceph:v' + (ceph_version | default('18.2.1'))) }}"
+    CEPH_CONTAINER_IMAGE: "{{ cephadm_image | default('quay.io/ceph/ceph:v' + (ceph_version | default('20.2.3'))) }}"
     CEPH_CONTAINER_BINARY: docker
 
 - name: Deploy Ceph exporters
@@ -45,5 +45,5 @@
       tags:
         - ceph-exporter
   environment:
-    CEPH_CONTAINER_IMAGE: "{{ cephadm_image | default('quay.io/ceph/ceph:v' + (ceph_version | default('18.2.1'))) }}"
+    CEPH_CONTAINER_IMAGE: "{{ cephadm_image | default('quay.io/ceph/ceph:v' + (ceph_version | default('20.2.3'))) }}"
     CEPH_CONTAINER_BINARY: docker

--- a/roles/ceph_exporter/tasks/main.yml
+++ b/roles/ceph_exporter/tasks/main.yml
@@ -17,6 +17,6 @@
   run_once: true
   vexxhost.ceph.orch_apply:
     fsid: "{{ ceph_exporter_fsid }}"
-    image: "{{ cephadm_image | default('quay.io/ceph/ceph:v' + (ceph_version | default('18.2.1'))) }}"
+    image: "{{ cephadm_image | default('quay.io/ceph/ceph:v' + (ceph_version | default('20.2.3'))) }}"
     docker: true
     spec: "{{ ceph_exporter_service_spec | to_nice_yaml }}"

--- a/roles/cephadm/defaults/main.yml
+++ b/roles/cephadm/defaults/main.yml
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 VEXXHOST, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-cephadm_version: "{{ ceph_version | default('18.2.1') }}"
+cephadm_version: "{{ ceph_version | default('20.2.3') }}"
 
 cephadm_http_proxy: "{{ http_proxy | default('') }}"
 cephadm_https_proxy: "{{ https_proxy | default('') }}"

--- a/roles/cephadm/meta/main.yml
+++ b/roles/cephadm/meta/main.yml
@@ -23,6 +23,7 @@ galaxy_info:
       versions:
         - focal
         - jammy
+        - noble
 
 dependencies:
   - role: vexxhost.containers.docker

--- a/roles/cephadm_host/meta/main.yml
+++ b/roles/cephadm_host/meta/main.yml
@@ -23,3 +23,4 @@ galaxy_info:
       versions:
         - focal
         - jammy
+        - noble

--- a/roles/mgr/meta/main.yml
+++ b/roles/mgr/meta/main.yml
@@ -23,6 +23,7 @@ galaxy_info:
       versions:
         - focal
         - jammy
+        - noble
 
 dependencies:
   - role: cephadm

--- a/roles/mgr/tasks/main.yml
+++ b/roles/mgr/tasks/main.yml
@@ -26,7 +26,7 @@
   run_once: true
   vexxhost.ceph.orch_apply:
     fsid: "{{ ceph_mgr_fsid }}"
-    image: "{{ cephadm_image | default('quay.io/ceph/ceph:v' + (ceph_version | default('18.2.1'))) }}"
+    image: "{{ cephadm_image | default('quay.io/ceph/ceph:v' + (ceph_version | default('20.2.3'))) }}"
     docker: true
     spec: |
       service_type: mgr

--- a/roles/mon/meta/main.yml
+++ b/roles/mon/meta/main.yml
@@ -23,6 +23,7 @@ galaxy_info:
       versions:
         - focal
         - jammy
+        - noble
 
 dependencies:
   - role: cephadm

--- a/roles/mon/tasks/main.yml
+++ b/roles/mon/tasks/main.yml
@@ -47,7 +47,7 @@
   run_once: true
   vexxhost.ceph.orch_apply:
     fsid: "{{ ceph_mon_fsid }}"
-    image: "{{ cephadm_image | default('quay.io/ceph/ceph:v' + (ceph_version | default('18.2.1'))) }}"
+    image: "{{ cephadm_image | default('quay.io/ceph/ceph:v' + (ceph_version | default('20.2.3'))) }}"
     docker: true
     spec: |
       service_type: mon

--- a/roles/osd/meta/main.yml
+++ b/roles/osd/meta/main.yml
@@ -23,6 +23,7 @@ galaxy_info:
       versions:
         - focal
         - jammy
+        - noble
 
 dependencies:
   - role: cephadm


### PR DESCRIPTION
## Summary

Updates the collection's default Ceph release from Reef 18.2.x to Tentacle 20.2.3 and declares Ubuntu Noble as a supported platform. Noble is already covered by the existing Molecule jobs.

## Changes

- Use Ceph 20.2.3 for every default cephadm and orchestrator image path.
- Remove the Zuul `ceph_version: 18.2.8` override so CI exercises the collection default.
- Discover the deployed monitor image with `cephadm ls --no-detail` during Molecule verification instead of requiring `ceph_version`.
- Add Ubuntu Noble to `galaxy_info` for the cephadm, cephadm_host, mon, mgr, and osd roles.

## Validation

- All changed YAML files parse successfully.
- `git diff --check` passes.
- `ansible-lint extensions/molecule/default/verify.yml` passes at the production profile.

## Related work

PR #120 carries the separate Ubuntu 26.04 support changes and also targets `main` independently.

Split from #105, originally contributed by @ricolin.
