### PR TITLE
feat: support Ubuntu 26.04

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,9 +8,9 @@ description: Ansible collection for deploying Ceph clusters
 license:
   - GPL-3.0-or-later
 dependencies:
-  community.general: '>=4.5.0'
+  community.general: '>=12.0.0'
   ansible.utils: '>=6.0.0'
-  vexxhost.containers: '>=1.1.1'
+  vexxhost.containers: '>=1.6.0'
 tags:
   - application
   - cloud

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "4.1.0"
 authors = [{ name = "VEXXHOST, Inc.", email = "support@vexxhost.com" }]
 description = "Ansible collection for deploying Ceph"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 license = "Apache-2.0"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
@@ -14,12 +14,13 @@ classifiers = [
   "Operating System :: POSIX :: Linux",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = [
-  "ansible-core>=2.18",
+  "ansible-core>=2.20",
   "docker-image-py>=0.1.12",
   "jmespath>=1.0.1",
   "netaddr>=1.3.0",

--- a/roles/cephadm/meta/main.yml
+++ b/roles/cephadm/meta/main.yml
@@ -23,6 +23,7 @@ galaxy_info:
       versions:
         - focal
         - jammy
+        - resolute
 
 dependencies:
   - role: vexxhost.containers.docker

--- a/roles/cephadm/tasks/main.yml
+++ b/roles/cephadm/tasks/main.yml
@@ -21,6 +21,27 @@
     - "{{ ansible_facts['distribution'] | lower }}.yml"
     - "{{ ansible_facts['os_family'] | lower }}.yml"
 
+# NOTE(ricolin): Ubuntu 26.04 ships uutils coreutils 0.7.0 as
+# /usr/bin/install, which rejects the numeric UID/GID arguments that
+# `cephadm bootstrap` passes (e.g. `install -o 167 -g 167 ...`) with
+# "install: invalid user: '167'". Swap to coreutils-from-gnu so GNU
+# install is used. The swap removes the essential coreutils-from-uutils
+# package, which apt refuses by default, so we pass
+# --allow-remove-essential explicitly.
+- name: Ensure GNU coreutils is used on Ubuntu 26.04
+  ansible.builtin.command:
+    argv:
+      - apt-get
+      - install
+      - --yes
+      - --allow-remove-essential
+      - coreutils-from-gnu
+  register: _cephadm_gnu_coreutils
+  changed_when: "'0 upgraded, 0 newly installed' not in _cephadm_gnu_coreutils.stdout"
+  when:
+    - ansible_facts['distribution'] == 'Ubuntu'
+    - ansible_facts['distribution_version'] is version('26.04', '==')
+
 - name: Install packages
   ansible.builtin.package:
     name: "{{ cephadm_packages }}"

--- a/roles/cephadm_host/meta/main.yml
+++ b/roles/cephadm_host/meta/main.yml
@@ -23,3 +23,4 @@ galaxy_info:
       versions:
         - focal
         - jammy
+        - resolute

--- a/roles/mgr/meta/main.yml
+++ b/roles/mgr/meta/main.yml
@@ -23,6 +23,7 @@ galaxy_info:
       versions:
         - focal
         - jammy
+        - resolute
 
 dependencies:
   - role: cephadm

--- a/roles/mon/meta/main.yml
+++ b/roles/mon/meta/main.yml
@@ -23,6 +23,7 @@ galaxy_info:
       versions:
         - focal
         - jammy
+        - resolute
 
 dependencies:
   - role: cephadm

--- a/roles/osd/meta/main.yml
+++ b/roles/osd/meta/main.yml
@@ -23,6 +23,7 @@ galaxy_info:
       versions:
         - focal
         - jammy
+        - resolute
 
 dependencies:
   - role: cephadm


### PR DESCRIPTION
## Summary

Adds Ubuntu 26.04 (Resolute) support as an independent change targeting `main`.

## Changes

- Declare Ubuntu Resolute support in `galaxy_info` across the collection roles.
- Require Python 3.12+, Ansible Core 2.20+, `community.general` 12+, and `vexxhost.containers` 1.6+.
- Add Python 3.13 and 3.14 classifiers.
- Replace Ubuntu 26.04's uutils coreutils package with GNU coreutils before cephadm bootstrap, because uutils `install` rejects the numeric Ceph UID/GID arguments.

## Validation

- The YAML and TOML files parse successfully.
- `git diff --check` passes.
- The original contributor validated the combined change as an AIO deployment on Ubuntu 26.04.3 with a healthy Ceph Tentacle cluster. That run used Ceph 20.2.1; the lower stack layer updates the tested default to 20.2.3.

## Related work

PR #119 separately updates the default Ceph release to 20.2.3 and adds Ubuntu Noble support. Neither PR depends on the other, so this change can land later.

Supersedes #105, originally contributed by @ricolin.
